### PR TITLE
Feature: Rate with localbitcoin only

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,11 @@
 const fetch = require('node-fetch');
-const LOCALBITCOINS_AR = "https://localbitcoins.com/sell-bitcoins-online/ARS//.json";
-const USD_RATE = "https://api.coindesk.com/v1/bpi/currentprice.json";
-
-const getUSDRate = async () => {
-    const data = await fetch(USD_RATE).then(res => res.json());
-    return data.bpi.USD.rate_float;
-}
-
-const getARSRate = async () => {
-    const data = await fetch(LOCALBITCOINS_AR).then(res => res.json());
-    const list = data.data.ad_list.slice(0, 30)
-    const sum = list.map(d => parseFloat(d.data.temp_price));
-    return sum.reduce((acc, d) => acc + d, 0) / list.length;
-}
+const LOCALBITCOINS_ALL_CURRENCIES = "https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/";
 
 const main = async () => {
-    const [ usdRate, arsRate ] = await Promise.all([
-        getUSDRate(),
-        getARSRate()
-    ]);
-    const rate = (arsRate / usdRate).toFixed(2)
-    console.log('Current rate is', rate);
+    const data = await fetch(LOCALBITCOINS_ALL_CURRENCIES).then(res => res.json());
+    const times = [24, 12, 6, 1]
+
+    times.forEach(time => console.log(`Rate with average ${time} hours: ${(data.ARS[`avg_${time}h`] / data.USD[`avg_${time}h`]).toFixed(2)} ARS/$`))
 }
 
 main().catch(console.log).then(() => process.exit(0))


### PR DESCRIPTION
Hola Asdrubal, revisando la api de localbitcoin, veo que publican el precio promedio del bitcoin en todas las monedas, promedios de 24, 12, 6 y una hora.

Por otro lado el precio del bitcoin también varía de acuerdo al mercado que consultes, lo ideal es que si sacamos el precio del dolar con respecto al ARG entonces que sea de la misma fuente o mismo mercado. 

Hice estos cambios a ver que opinas

esta es la ruta de la api [https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/](https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/)

![USD-rate](https://user-images.githubusercontent.com/3742594/82112332-e7f82f80-9719-11ea-9f27-9e4aded74006.png)

![ARS-rate](https://user-images.githubusercontent.com/3742594/82112418-d400fd80-971a-11ea-98ea-10f68921c862.gif)

